### PR TITLE
Added the ability to set the README file path via an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ This image uses environment variables for configuration.
 |`DOCKERHUB_PASSWORD`    |no default           |Password of the `DOCKERHUB_USERNAME`-user           |
 |`DOCKERHUB_REPO_PREFIX` |`$DOCKERHUB_USERNAME`|Organisation or username for the repository         |
 |`DOCKERHUB_REPO_NAME`   |no default           |Name of the repository you want to push to          |
+|`README_PATH`           |`/data/README.md`    |Path to the README.me to push                       |
 
 
 ## Mount the README.md
 
-This image always pushes the file `/data/README.md` as full description to Docker Hub.
+By default, if the `README_PATH` environment variable is not set, this image always pushes the file
+`/data/README.md` as full description to Docker Hub.
 
 For GitHub repositories you can use `-v /path/to/repository:/data/`.
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ dockerHubAPI.login(process.env.DOCKERHUB_USERNAME, process.env.DOCKERHUB_PASSWOR
     dockerHubAPI.setLoginToken(info.token);
 }).then(function () {
     // Load README
-    var filePath = path.join('/data' , 'README.md');
+    var filePath = process.env.README_PATH || path.join('/data' , 'README.md');
     const readme = fs.readFileSync(filePath, {encoding: 'utf-8'});
 
     // Update repository description


### PR DESCRIPTION
This is useful to integrate with services where mapping `/data/README.md` is not possible.  For example, codefresh.io is one of them.