### PR TITLE
Fix unhandled promise rejection not terminating

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /app/
 
 RUN npm install
 
-ENTRYPOINT ["node", "/app/index.js"]
+ENTRYPOINT ["node", "--unhandled-rejections=strict", "/app/index.js"]


### PR DESCRIPTION
Currently, if only username or password are provided, the application fails, but doesn't exit.

This patch sets unhandledPromiseRejections to strict which causes node to exit on unhandled promise rejections. This should result in not perfectly handled but at least properly breaking behaviour.

This patch should fixed the problem that appeared in #109